### PR TITLE
Modify imports in template so that evaluation_tests.py can be run from inside the 'app' folder

### DIFF
--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -1,6 +1,9 @@
 import unittest
 
-from .evaluation import evaluation_function
+try:
+    from .evaluation import evaluation_function
+except ImportError:
+    from evaluation import evaluation_function
 
 class TestEvaluationFunction(unittest.TestCase):
     """


### PR DESCRIPTION
The import code now checks if evaluation.py is in the parent folder and if it is not it attempts to import it from the current folder.

I have attempted to configure my preferred debugger so that it will work when running evaluation_tests.py from the parent folder but failed. Solving it this way is much easier for me but I do not know if there are any undesired consequences.